### PR TITLE
Fix initialization of start and end years in ZipCodeUtility class

### DIFF
--- a/industries/naics/naics-annual.ipynb
+++ b/industries/naics/naics-annual.ipynb
@@ -6199,36 +6199,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "zip_util.get_all_zip_zbp(zipcodes)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "years() missing 1 required positional argument: 'end'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[5], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mutilities\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcounty_utility\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mcu\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m county_util \u001b[38;5;241m=\u001b[39m \u001b[43mcu\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mCountyUtility\u001b[49m\u001b[43m(\u001b[49m\u001b[43mapi_headers\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mapi_headers\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mstate_fips\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mstate_fips\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mbase_path\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcounty_data_dir\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      4\u001b[0m county_util\u001b[38;5;241m.\u001b[39mget_county_cbp(state\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m02\u001b[39m\u001b[38;5;124m'\u001b[39m,fips\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m02\u001b[39m\u001b[38;5;124m'\u001b[39m)\n",
-      "File \u001b[0;32m~/Desktop/webroot/data-pipeline/industries/naics/utilities/county_utility.py:22\u001b[0m, in \u001b[0;36mCountyUtility.__init__\u001b[0;34m(self, state_fips, base_path, startyear, endyear, api_headers)\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mbase_url \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhttps://api.census.gov/data\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     21\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m validate_inputs(base_path, startyear, endyear):\n\u001b[0;32m---> 22\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43myears\u001b[49m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mrange\u001b[39m(startyear, endyear \u001b[38;5;241m+\u001b[39m \u001b[38;5;241m1\u001b[39m)\n\u001b[1;32m     23\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mbase_path \u001b[38;5;241m=\u001b[39m Path(base_path)\n",
-      "\u001b[0;31mTypeError\u001b[0m: years() missing 1 required positional argument: 'end'"
-     ]
-    }
-   ],
-   "source": [
-    "import utilities.county_utility as cu\n",
-    "\n",
-    "county_util = cu.CountyUtility(api_headers=api_headers, state_fips=state_fips, base_path=county_data_dir)\n",
-    "county_util.get_county_cbp(state='02',fips='02')"
+    "zip_util.get_zip_zbp(zipcodes)"
    ]
   }
  ],

--- a/industries/naics/utilities/zipcode_utility.py
+++ b/industries/naics/utilities/zipcode_utility.py
@@ -9,20 +9,22 @@ import os
 default_path = '../../../community-data/industries/naics/US/zips'
 
 class ZipCodeUtility():
-    def __init__(self, startyear = 2000, endyear = None, api_headers = None, base_path = default_path):
+    def __init__(self, startyear = 2000, endyear = 2023, api_headers = None, base_path = default_path):
         self.api_headers = api_headers
         self.base_url = "https://api.census.gov/data"
+        self.startyear = startyear
+        self.endyear = endyear
         if endyear is None:
-            endyear = datetime.datetime.now().year - 1
+            self.endyear = datetime.datetime.now().year - 1
         if self._validate_inputs(base_path, startyear, endyear):
-            self.years = range(startyear, endyear + 1)
             self.base_path = Path(base_path)
     
     # Gets data for one zipcode within a range of years
     def get_zip_zbp(self, zipcode):
         cache_dir = self._zipcode_data_dir(zipcode, cache=True, year=None)
         file_handlers = {}
-        for year in self.years:
+        years = range(self.startyear, self.endyear+1)
+        for year in years:
             print(f"Getting data for zipcode: {zipcode}\tyear: {year}")
             data, status_code = self._get_response_data(zipcode, year, cache_dir)
             


### PR DESCRIPTION
Resolved an issue where the start and end years were not being properly initialized in the ZipCodeUtility class, causing incorrect handling of year ranges. This makes sure that the class now correctly sets up start and end years based on provided parameters or defaults.
